### PR TITLE
Add capability to the container for wait until bookkeeper is available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ build-java:
 	mvn clean install
 
 build-docker:
+	-docker rmi $(IMAGE):$(VERSION) $(IMAGE):latest
 	cp -afv target/tutorial-$(VERSION)-jar-with-dependencies.jar docker/bookkeeper-tutorial.jar
 	cd docker; docker build \
 		-t $(IMAGE):$(VERSION) -t $(IMAGE):latest \

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ build-java:
 	mvn clean install
 
 build-docker:
-	-docker rmi $(IMAGE):$(VERSION) $(IMAGE):latest
 	cp -afv target/tutorial-$(VERSION)-jar-with-dependencies.jar docker/bookkeeper-tutorial.jar
 	cd docker; docker build \
 		-t $(IMAGE):$(VERSION) -t $(IMAGE):latest \

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -5,6 +5,14 @@ if [ "${ZOOKEEPER_SERVERS}" = "" ]; then
 	exit
 fi
 
+# Wait for bookies
+if [ ! -z "${BOOKKEEPER_SERVER}" ]; then
+    while ! nc -z -w 2 ${BOOKKEEPER_SERVER} 3181; do
+        sleep 1
+    done
+    echo "Connected to bookie: ${BOOKKEEPER_SERVER}"
+fi
+
 set -x
 
 java -jar /local/bookkeeper-tutorial.jar --zookeeper-servers ${ZOOKEEPER_SERVERS}

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -5,9 +5,11 @@ if [ "${ZOOKEEPER_SERVERS}" = "" ]; then
 	exit
 fi
 
-# Wait for bookies
+# Wait for bookkeeper
+BOOKKEEPER_PORT=${BOOKKEEPER_PORT:-3181}
+
 if [ ! -z "${BOOKKEEPER_SERVER}" ]; then
-    while ! nc -z -w 2 ${BOOKKEEPER_SERVER} 3181; do
+    while ! nc -z -w 2 ${BOOKKEEPER_SERVER} ${BOOKKEEPER_PORT}; do
         sleep 1
     done
     echo "Connected to bookie: ${BOOKKEEPER_SERVER}"


### PR DESCRIPTION
It turned out that if the dice try to connect to bookkeeper and it's not available it fails.
This patches modify the init script of the Dockerfile to wait until the bookkeeper server is available, solving the issue, receiving the bookkeeper server and port as environment parameters.

Related.- https://github.com/apache/bookkeeper/issues/328